### PR TITLE
update default to correct nuopc.runseq in NEMO coupled cases

### DIFF
--- a/cime_config/config_component_cesm.xml
+++ b/cime_config/config_component_cesm.xml
@@ -412,6 +412,7 @@
     <values match="last">
       <value compset="_DATM.*_DOCN%SOM"			>OPTION2</value>
       <value compset="_POP2"				>OPTION2</value>
+      <value compset="_NEMO"				>OPTION2</value>
       <value compset="_MOM6"				>OPTION1</value>
       <value compset="_POP2" grid="oi%gx1v6"		>OPTION1</value>
       <value compset="_POP2" grid="oi%gx1v7"		>OPTION1</value>
@@ -506,6 +507,7 @@
       <value compset="DATM.*_MOM\d">TRUE</value>
       <value compset="CAM.*_MOM\d">TRUE</value>
       <value compset="CAM.*_POP\d">TRUE</value>
+      <value compset="CAM.*_NEMO">FALSE</value>
       <value compset="CAM.*_DOCN%SOM">TRUE</value>
     </values>
     <group>run_budgets</group>


### PR DESCRIPTION
### Description of changes

changed the CPL_SEQ_OPTION option in config_component_cesm.xml for NEMO compsets

### Specific notes

Contributors other than yourself, if any:

CMEPS Issues Fixed (include github issue #):
Fixes issue #3 

Are changes expected to change answers? (specify if bfb, different at roundoff, more substantial) 

Any User Interface Changes (namelist or namelist defaults changes)?

### Testing performed
2-days coupled simulation

Testing performed if application target is CESM:
- [ ] (recommended) CIME_DRIVER=nuopc scripts_regression_tests.py
   - machines:
   - details (e.g. failed tests):
- [ ] (recommended) CESM testlist_drv.xml
   - machines and compilers:
   - details (e.g. failed tests):
- [ ] (optional) CESM prealpha test
   - machines and compilers
   - details (e.g. failed tests):
- [ ] (other) please described in detail
   - machines and compilers
   - details (e.g. failed tests):

Testing performed if application target is UFS-coupled:
- [ ] (recommended) UFS-coupled testing
   - description:
   - details (e.g. failed tests):

Testing performed if application target is UFS-HAFS:
- [ ] (recommended) UFS-HAFS testing
   - description:
   - details (e.g. failed tests):

### Hashes used for testing:

- [ ] CESM:
  - repository to check out: https://github.com/ESCOMP/CESM.git
  - branch/hash:
- [ ] UFS-coupled, then umbrella repostiory to check out and associated hash:
  - repository to check out:
  - branch/hash:
- [ ] UFS-HAFS, then umbrella repostiory to check out and associated hash:
  - repository to check out:
  - branch/hash:
