### PR TITLE
Add NEMO_REBUILD and NEMO_REBUILD_ROOT flags

### DIFF
--- a/cime_config/config_component.xml
+++ b/cime_config/config_component.xml
@@ -557,6 +557,28 @@
   </entry>
 
   <!-- ===================================================================== -->
+  <!-- definitions nemo_rebuild -->
+  <!-- ===================================================================== -->
+
+  <entry id="NEMO_REBUILD">
+    <type>logical</type>
+    <valid_values>TRUE,FALSE</valid_values>
+    <default_value>FALSE</default_value>
+    <group>run_data_archive</group>
+    <file>env_run.xml</file>
+    <desc>if true, NEMO output files rebuild is performed at the end of run</desc>
+  </entry>
+
+  <entry id="NEMO_REBUILD_ROOT">
+    <type>char</type>
+    <valid_values></valid_values>
+    <default_value>$ENV{CIMEROOT}/../components/nemo/source/utils</default_value>
+    <group>run_data_archive</group>
+    <file>env_run.xml</file>
+    <desc>directory where the script to rebuild the NEMO multiple outputs is</desc>
+  </entry>
+
+  <!-- ===================================================================== -->
   <!-- definitions machines specific -->
   <!-- ===================================================================== -->
 


### PR DESCRIPTION
### Description of changes

Add two flags for NEMO rebuild 
* NEMO_REBUILD
* NEMO_REBUILD_ROOT

These two flags need to be available in cmeps to be used in all configuration and to be activated only in the nemo configurations.

### Specific notes

Contributors other than yourself, if any:

CMEPS Issues Fixed (include github issue #):

Are changes expected to change answers? (specify if bfb, different at roundoff, more substantial) 

Any User Interface Changes (namelist or namelist defaults changes)?

### Testing performed
Please describe the tests along with the target model and machine(s) 
If possible, please also added hashes that were used in the testing

